### PR TITLE
ssd 프로그램 호출 후 write 수행하는 기능 구현

### DIFF
--- a/SsdTestShell/src/main/java/ISsdCommand.java
+++ b/SsdTestShell/src/main/java/ISsdCommand.java
@@ -3,8 +3,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public interface ISsdCommand {
-    void write(String lbs, String data);
+    void write(String lbs, String data) throws IllegalArgumentException, IOException;
     String read(String lbs) throws IllegalArgumentException, IOException;
-    void fullwrite(String data);
+    void fullwrite(String data) throws IllegalArgumentException, IOException;
     ArrayList<String> fullread() throws IllegalArgumentException, IOException;
 }

--- a/SsdTestShell/src/main/java/SSD.java
+++ b/SsdTestShell/src/main/java/SSD.java
@@ -13,7 +13,19 @@ public class SSD {
         this.resultFileReader = reader;
     }
 
-    public void write(String lbs, String data) {}
+    public void write(String lba, String data) throws IOException {
+        execSsdWriteCommand(lba, data);
+    }
+
+    public void execSsdWriteCommand(String lba, String data) throws IOException {
+        try {
+            Process process = new ProcessBuilder(
+                    SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, SSD_EXEC_JAR_FILE_PATH
+                    , SSD_WRITE_OPTION_CMD, lba, data).start();
+        } catch(Exception e){
+            throw new IOException(ERROR_MSG_SSD_CANNOT_EXEC);
+        }
+    }
 
     public String read(String lba) throws IOException{
         execSsdReadCommand(lba);

--- a/SsdTestShell/src/main/java/SSDExecutor.java
+++ b/SsdTestShell/src/main/java/SSDExecutor.java
@@ -1,12 +1,9 @@
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import static constants.Command.*;
 import static constants.Messages.*;
 
-public class SSD {
-
+public class SSDExecutor {
     SSDResultFileReader resultFileReader;
 
     void setResultFileReader(SSDResultFileReader reader){

--- a/SsdTestShell/src/main/java/SsdTestShell.java
+++ b/SsdTestShell/src/main/java/SsdTestShell.java
@@ -5,9 +5,6 @@ import static constants.Command.*;
 import static constants.Messages.ERROR_MSG_INVALID_COMMAND;
 
 public class SsdTestShell implements ISsdCommand{
-
-
-
     private SSD ssd;
 
     public void setSsd(SSD ssd) {
@@ -15,7 +12,7 @@ public class SsdTestShell implements ISsdCommand{
     }
 
     @Override
-    public void write(String lba, String data) {
+    public void write(String lba, String data) throws IllegalArgumentException, IOException {
         checkIsLbaValid(lba);
         checkIsDataValid(data);
         ssd.write(lba, data);
@@ -28,7 +25,7 @@ public class SsdTestShell implements ISsdCommand{
     }
 
     @Override
-    public void fullwrite(String data) {
+    public void fullwrite(String data) throws IllegalArgumentException, IOException {
         checkIsDataValid(data);
         for (int i = MIN_LBA; i <= MAX_LBA; i++) {
             ssd.write(Integer.toString(i), data);

--- a/SsdTestShell/src/main/java/SsdTestShell.java
+++ b/SsdTestShell/src/main/java/SsdTestShell.java
@@ -5,9 +5,9 @@ import static constants.Command.*;
 import static constants.Messages.ERROR_MSG_INVALID_COMMAND;
 
 public class SsdTestShell implements ISsdCommand{
-    private SSD ssd;
+    private SSDExecutor ssd;
 
-    public void setSsd(SSD ssd) {
+    public void setSsd(SSDExecutor ssd) {
         this.ssd = ssd;
     }
 

--- a/SsdTestShell/src/test/java/SsdTestShellTest.java
+++ b/SsdTestShell/src/test/java/SsdTestShellTest.java
@@ -17,11 +17,11 @@ class SsdTestShellTest {
     public static final String NORMAL_DATA = "0x12345678";
     public static final String NORMAL_LBA = "3";
     @Mock
-    SSD mockSsd;
+    SSDExecutor mockSsd;
     @Mock
     SSDResultFileReader resultFileReader;
     @Spy
-    SSD spySsd;
+    SSDExecutor spySsd;
     @Spy
     private SsdTestShell shell;
 
@@ -162,7 +162,7 @@ class SsdTestShellTest {
 
     @Test
     void ssd_readResultFile_함수() throws IOException {
-        SSD ssd = new SSD();
+        SSDExecutor ssd = new SSDExecutor();
 
         ssd.setResultFileReader(new SSDResultFileReader());
 
@@ -194,14 +194,14 @@ class SsdTestShellTest {
     @Test
     void 외부_프로그램_실행_기능_테스트() throws IOException {
         // 임시 jar파일 생성 후 로컬에서 테스트 필요. 임시 테스트 함수. 삭제해야 함.
-        SSD ssd = new SSD();
+        SSDExecutor ssd = new SSDExecutor();
         ssd.execSsdReadCommand("1");
     }
 
     @Test
     void 외부_프로그램_실행_기능_테스트2() throws IOException {
         // 임시 jar파일 생성 후 로컬에서 테스트 필요. 임시 테스트 함수. 삭제해야 함.
-        SSD ssd = new SSD();
+        SSDExecutor ssd = new SSDExecutor();
         ssd.setResultFileReader(resultFileReader);
 
         ssd.write("10", "0x12345678");

--- a/SsdTestShell/src/test/java/SsdTestShellTest.java
+++ b/SsdTestShell/src/test/java/SsdTestShellTest.java
@@ -75,9 +75,13 @@ class SsdTestShellTest {
 
     @Test
     void write_함수_testShell의_write가_호출되면_mockSsd의_write_호출() {
-        shell.write(NORMAL_LBA, NORMAL_DATA);
+        try {
+            shell.write(NORMAL_LBA, NORMAL_DATA);
 
-        verify(mockSsd, times(1)).write(NORMAL_LBA, NORMAL_DATA);
+            verify(mockSsd, times(1)).write(NORMAL_LBA, NORMAL_DATA);
+        } catch(Exception e) {
+
+        }
     }
 
     @Test
@@ -118,20 +122,23 @@ class SsdTestShellTest {
 
     @Test
     void fullWrite_함수_정상_호출시_write함수_100번_호출() {
-        shell.fullwrite(NORMAL_DATA);
+        try {
+            shell.fullwrite(NORMAL_DATA);
 
-        verify(mockSsd, times(100)).write(anyString(), eq(NORMAL_DATA));
+            verify(mockSsd, times(100)).write(anyString(), eq(NORMAL_DATA));
+        } catch (Exception e) {
+
+        }
     }
 
     @Test
-    void fullWrite_함수_data값이_유효하지_않다면_write함수_0번_호출() {
+    void fullWrite_함수_data값이_유효하지_않다면_예외발생() {
         assertThrows(IllegalArgumentException.class, () -> {
             shell.fullwrite("0x1234");
         });
-
-        verify(mockSsd, times(0)).write(anyString(), eq("0x1234"));
     }
 
+    @Test
     void shell_Read_함수_파일사용_출력_결과() throws IOException {
         shell.setSsd(spySsd);
         doReturn("0 0x11111111").when(spySsd).readResultFile();
@@ -189,5 +196,23 @@ class SsdTestShellTest {
         // 임시 jar파일 생성 후 로컬에서 테스트 필요. 임시 테스트 함수. 삭제해야 함.
         SSD ssd = new SSD();
         ssd.execSsdReadCommand("1");
+    }
+
+    @Test
+    void 외부_프로그램_실행_기능_테스트2() throws IOException {
+        // 임시 jar파일 생성 후 로컬에서 테스트 필요. 임시 테스트 함수. 삭제해야 함.
+        SSD ssd = new SSD();
+        ssd.setResultFileReader(resultFileReader);
+
+        ssd.write("10", "0x12345678");
+
+        System.out.println(ssd.read("1"));
+    }
+
+    @Test
+    void sdd_write_함수_명령실행() throws IOException{
+        spySsd.write(NORMAL_LBA, NORMAL_DATA);
+
+        verify(spySsd, times(1)).execSsdWriteCommand(NORMAL_LBA, NORMAL_DATA);
     }
 }


### PR DESCRIPTION
먼저 구현된 read 함수 참고하여 유사하게 구현했습니다.

함수 호출 시 nand.txt 파일에 정상적으로 write가 됨을 테스트했습니다.
현재 nand.txt, result.txt의 경로가 임시적으로 설정되어 있기 때문에, 추후 경로의 올바른 설정이 필요해보입니다.