### PR TITLE
[bugfix] 연속적으로 ssd read/write 호출 시 정상동작하지 않는 이슈 임시 보완 (read/write 후 딜레이 설정)

### DIFF
--- a/SsdTestShell/src/main/java/SSDExecutor.java
+++ b/SsdTestShell/src/main/java/SSDExecutor.java
@@ -2,6 +2,7 @@ import java.io.IOException;
 
 import static constants.Command.*;
 import static constants.Messages.*;
+import static java.lang.Thread.sleep;
 
 public class SSDExecutor {
     SSDResultFileReader resultFileReader;
@@ -23,10 +24,10 @@ public class SSDExecutor {
 
     public void execSsdWriteCommand(String lba, String data) throws IOException {
         try {
-            Thread.sleep(10);
             Process process = new ProcessBuilder(
                     SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, ssdProgramPath
                     , SSD_WRITE_OPTION_CMD, lba, data).start();
+            sleep(50); // 성공 최소 시간(30ms)의 1.5배로 설정
         } catch(Exception e){
             throw new IOException(ERROR_MSG_SSD_CANNOT_EXEC);
         }
@@ -39,10 +40,10 @@ public class SSDExecutor {
 
     public void execSsdReadCommand(String lba) throws IOException {
         try {
-            Thread.sleep(10);
             new ProcessBuilder(
                     SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, ssdProgramPath
                     , SSD_EXEC_READ_OPTION, lba).start();
+            sleep(120); // 성공 최소 시간(80ms)의 1.5배로 설정
         } catch(Exception e){
             throw new IOException(ERROR_MSG_SSD_CANNOT_EXEC);
         }

--- a/SsdTestShell/src/main/java/SSDExecutor.java
+++ b/SsdTestShell/src/main/java/SSDExecutor.java
@@ -26,8 +26,9 @@ public class SSDExecutor {
         try {
             Process process = new ProcessBuilder(
                     SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, ssdProgramPath
-                    , SSD_WRITE_OPTION_CMD, lba, data).start();
-            sleep(50); // 성공 최소 시간(30ms)의 1.5배로 설정
+                    , SSD_WRITE_OPTION_CMD, lba, data)
+                    .start();
+            process.waitFor();
         } catch(Exception e){
             throw new IOException(ERROR_MSG_SSD_CANNOT_EXEC);
         }
@@ -40,10 +41,11 @@ public class SSDExecutor {
 
     public void execSsdReadCommand(String lba) throws IOException {
         try {
-            new ProcessBuilder(
+            Process process = new ProcessBuilder(
                     SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, ssdProgramPath
-                    , SSD_EXEC_READ_OPTION, lba).start();
-            sleep(120); // 성공 최소 시간(80ms)의 1.5배로 설정
+                    , SSD_EXEC_READ_OPTION, lba)
+                    .start();
+            process.waitFor();
         } catch(Exception e){
             throw new IOException(ERROR_MSG_SSD_CANNOT_EXEC);
         }

--- a/SsdTestShell/src/test/java/SsdTestShellTest.java
+++ b/SsdTestShell/src/test/java/SsdTestShellTest.java
@@ -226,25 +226,25 @@ class SsdTestShellTest {
         SSDResultFileReader reader = new SSDResultFileReader();
         shell.setSsd(ssd);
         ssd.setResultFileReader(reader);
-        // ssd jar파일이 준비되지 않으면 자동 패스
+
         try {
-            // 파일이 없으면 이 테스트는 그냥 종료토록 함
             new ProcessBuilder(
                     SSD_EXEC_JAVA_COMMAND, SSD_EXEC_JAR_OPTION, "C:\\test\\ssd.jar"
                     , SSD_EXEC_READ_OPTION, "10").start();
 
             ssd.setSsdProgramPath("C:\\test\\ssd.jar");
-            reader.setResultFilePath("C:\\test\\result.txt");
 
-            shell.fullwrite("0xFFFFFFFE");
-            assertEquals("10 0xFFFFFFFE", shell.read("10"));
-
-            Thread.sleep(100);
+            shell.fullwrite("0x12345678");
+            assertEquals("0x12345678", shell.read("10"));
 
             ArrayList<String> list = shell.fullread();
+            for (int i = 0; i < 100; i++) {
+                assertEquals("0x12345678", list.get(i));
+            }
             assertEquals(100, list.size());
         } catch(Exception e){
             System.out.println("외부 프로그램 존재하지 않아 자동 패스합니다.");
+            System.out.println("테스트 전 C:\\test\\ssd.jar 파일을 세팅해주세요.");
         }
     }
 }


### PR DESCRIPTION
현재 ssd read/write 프로세스를 연속적으로 실행하면 정상 동작되지 않는 이슈가 있습니다.
(nand.txt에 write되지 않음, result.txt에 값이 갱신되기 전에 값을 읽음, result.txt 파일 읽으면 null값 읽힘 등)

이를 임시적으로 해결하기 위해 ssd read/write 프로세스 실행 후 일정 시간 딜레이를 주는 방법을 이용하려고 합니다.
로컬 pc에서 테스트해보니, 최소한 write 후 30ms, read 후 80ms 딜레이를 준 경우 정상 실행되는 것을 확인했습니다.
pc마다 딜레이 값이 달라질 것을 고려하여 각 최소 딜레이의 1.5배인 write 후 50ms, read 후 120ms를 딜레이로 설정했습니다.

결론적으로,
write : 50ms, read : 120ms, fullwrite : 5초, fullread : 12초
가 걸리게 됩니다.
기능 수행에 적지 않은 시간이 걸리게 되므로, 시간을 줄일 수 있는 더 좋은 방법을 찾는 것이 필요해보입니다.