### PR TITLE
[Add] SSD E 명령어 구현

### DIFF
--- a/SSD/src/main/java/erase/EraseModule.java
+++ b/SSD/src/main/java/erase/EraseModule.java
@@ -20,8 +20,8 @@ public class EraseModule extends SSDCommonUtils implements EraseCore {
 
     @Override
     public void E(int lba, int size) {
-        if(this.checkLbaBoundary(lba) && checkValidSize(size)) {
-            for(int startLba = lba; startLba < MAX_BOUNDARY; startLba += 1) {
+        if (this.checkLbaBoundary(lba) && checkValidSize(size)) {
+            for (int startLba = lba; startLba < MAX_BOUNDARY && startLba < lba + size; startLba += 1) {
                 fileWriter.store(startLba, DEFAULT_VALUE);
             }
         }

--- a/SSD/src/test/java/erase/EraseModuleTest.java
+++ b/SSD/src/test/java/erase/EraseModuleTest.java
@@ -81,6 +81,39 @@ class EraseModuleTest {
         testStateToEachLba(92, 99, DEFAULT_VALUE);
     }
 
+    @Test
+    void 전체범위_쓰고_지우기() {
+        String[] values = new String[]{
+                "0x11111111",
+                "0x22222222",
+                "0x33333333",
+                "0x44444444",
+                "0x55555555",
+                "0x66666666",
+                "0x77777777",
+                "0xAAAAAAAA",
+                "0xCCCCCCCC",
+                "0xFFFFFFFF",
+        };
+        int[] startLba = new int[]{0, 10, 20, 30 ,40 ,50 ,60 ,70, 80, 90};
+
+        for(int i = 0; i < 10; i += 1) {
+            int lba = startLba[i];
+            setUpStates(lba, lba + 10, values[i]);
+            this.eraseModule.E(lba + 1, 10);
+        }
+
+        for(int i = 0; i < 10; i += 1) {
+            int lba = startLba[i];
+            String expected = values[i];
+
+            this.readModule.read(lba);
+            String actual = getReadResult();
+
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
     private String getReadResult() {
         try {
             return new BufferedReader(new FileReader(

--- a/SSD/src/test/java/ssd/ssdFullTest.java
+++ b/SSD/src/test/java/ssd/ssdFullTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ssdFullTest {
 
     public static final String SAMPLE_VALUE = "0x1289CDEF";
-    public static final int EXITST_VALUE_LBA = 20;
+    public static final int EXITS_VALUE_LUBA = 20;
     public static final int NULL_VALUE_LBA = 10;
 
     private WriteCore writeCore;
@@ -40,15 +40,15 @@ public class ssdFullTest {
 
     @Test
     void 입력한_주소_Value_출력() throws IOException {
-        writeCore.write(EXITST_VALUE_LBA, SAMPLE_VALUE);
-        readCore.read(EXITST_VALUE_LBA);
+        writeCore.write(EXITS_VALUE_LUBA, SAMPLE_VALUE);
+        readCore.read(EXITS_VALUE_LUBA);
 
         assertEquals(SAMPLE_VALUE, getReadResult());
     }
 
     @Test
     void 입력하지않은_주소_Value_출력() throws IOException {
-        writeCore.write(EXITST_VALUE_LBA, SAMPLE_VALUE);
+        writeCore.write(EXITS_VALUE_LUBA, SAMPLE_VALUE);
         readCore.read(NULL_VALUE_LBA);
 
         assertEquals(DEFAULT_VALUE, getReadResult());


### PR DESCRIPTION
## 📝 요약

`SSD`의 `E` 명령어 구현하였습니다.
test coverage는 100% 달성하였습니다.

<br/>

## 💡 주의사항

1. `유효한 LBA` 값에서 시작했지만 범위를 벗어나면, `MAX_BOUNDARY`(100)까지만 `erase` 합니다.
> 99까지 제거하고 벗어날 경우 무시합니다.
2. `size`가 `10`을 초과하면, `EraseModule` 에선 **어떠한 동작도 하지 않습니다.**
>  또는 0일경우
 
<br/><br/>
