### PR TITLE
[bugfix] testApp2, testAppTest 메서드에 exception throw 추가

### DIFF
--- a/SsdTestShell/src/main/java/TestApp2.java
+++ b/SsdTestShell/src/main/java/TestApp2.java
@@ -1,3 +1,5 @@
+import java.io.IOException;
+
 public class TestApp2 implements Scenario {
     public static final int LOOP_COUNT = 30;
     public static final String OLD_DATA = "0xAAAABBBB";
@@ -32,7 +34,7 @@ public class TestApp2 implements Scenario {
         }
     }
 
-    private void rangeWrite(String data) throws IllegalArgumentException{
+    private void rangeWrite(String data) throws IllegalArgumentException, IOException {
         for (int i = START_LBA; i <= END_LBA; i++) {
             shell.write(Integer.toString(i), data);
         }

--- a/SsdTestShell/src/test/java/TestAppTest.java
+++ b/SsdTestShell/src/test/java/TestAppTest.java
@@ -17,7 +17,7 @@ class TestAppTest {
     SsdTestShell shell;
 
     @Test
-    void TestApp1_정상_동작_테스트() {
+    void TestApp1_정상_동작_테스트() throws IOException {
         Scenario testApp1 = spy(new TestApp1(shell));
 
         testApp1.testRun();
@@ -27,7 +27,7 @@ class TestAppTest {
     }
 
     @Test
-    void TestApp1_예외발생시_테스트_실패() {
+    void TestApp1_예외발생시_테스트_실패() throws IOException {
         Scenario testApp1 = spy(new TestApp1(shell));
         doThrow(new IOException()).when(shell).fullread();
 
@@ -37,7 +37,7 @@ class TestAppTest {
     }
 
     @Test
-    void TestApp1_fullread한_값이_0x12345678이_아니면_테스트_실패() {
+    void TestApp1_fullread한_값이_0x12345678이_아니면_테스트_실패() throws IOException {
         Scenario testApp1 = spy(new TestApp1(shell));
         doReturn(new ArrayList<String>(Arrays.asList("0x87654321"))).when(shell).fullread();
 


### PR DESCRIPTION
testApp 브랜치를 test_shell 브랜치로 merge하는 과정에서 예외 처리에 대한 에러가 생긴 것을 확인했습니다.

 TestApp을 사용하는 메서드에 exception throw가 추가되도록 간단하게 수정했으니, 확인 부탁드립니다.